### PR TITLE
docs: document minimal first-run mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,20 @@ asr:
   device: "cuda"
 ```
 
+For a minimal first run without Telegram or Google Sheets credentials, disable
+the optional integrations copied from [`config.example.yaml`](config.example.yaml):
+
+```yaml
+analytics:
+  telegram:
+    enabled: false
+google_sheets:
+  enabled: false
+```
+
+The core local pipeline still works in this mode: it can process files from
+`input/`, run ASR and LLM post-processing, and write local JSON/text artifacts.
+
 If you want to use a remote OpenAI-compatible LLM instead of a local server, point `vllm.base_url` and `quality_analysis.base_url` at that endpoint. Use placeholders in repo-tracked config and keep real hostnames in local config or environment overrides only.
 
 ### 3. Run the web layer

--- a/README_EN.md
+++ b/README_EN.md
@@ -76,6 +76,20 @@ cp config.example.yaml config.yaml
 cp branches.example.yaml branches.yaml
 ```
 
+For a minimal first run without Telegram or Google Sheets credentials, disable
+the optional integrations copied from [`config.example.yaml`](config.example.yaml):
+
+```yaml
+analytics:
+  telegram:
+    enabled: false
+google_sheets:
+  enabled: false
+```
+
+The core pipeline still works in this mode: local folder input, ASR, LLM
+post-processing, and JSON/text artifacts remain available.
+
 Recommended first checks:
 
 ```bash


### PR DESCRIPTION
## Problem
New users following the quick start may not have Telegram bot or Google Sheets credentials ready, even though the core local pipeline can run without those optional integrations.

## Solution
- Add a minimal-mode config snippet to `README.md` and `README_EN.md`
- Show the exact `analytics.telegram.enabled: false` and `google_sheets.enabled: false` keys from `config.example.yaml`
- Clarify that folder input, ASR, LLM post-processing, and local JSON/text artifacts still work

## Validation
- `git diff --check`

Related issue: #17

Confidence: 86/100 (docs)
