### PR TITLE
Release v5.2.0: staff review and maintenance refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [5.2.0] - 2026-06-12
+
+### Added
+- `docs/reviews/STAFF_REVIEW_2026-06.md` — full staff review, tech-delta matrix, and deferred GPU upgrade notes
+- Minimal first-run documentation in `README.md` and `README_EN.md` — disable Telegram and Google Sheets while keeping ASR → LLM → local artifacts
+- WSL2 deployment notes in `DEPLOYMENT_GUIDE.md` (experimental Windows path)
+- Reverse-proxy note for upload rate limiting behind `X-Forwarded-For`
+
+### Changed
+- Version unified at **5.2.0** (`pyproject.toml`, `src/__init__.py`, FastAPI app metadata)
+- CI: `actions/checkout@v6`, `astral-sh/setup-uv@v7` — apply manually on GitHub (workflow file requires `workflow` OAuth scope from local push)
+- `pydantic` 2.10.3 → 2.12.5, `pydantic-settings` 2.6.1 → 2.7.1
+- `pytest.ini` and `pyproject.toml` — exclude `voip/` from default collection to avoid import collisions
+- `config.example.yaml` — minimal-mode header comment
+- `docs/README.md`, `docs/ROADMAP.md` — linked staff review and marked minimal docs / WSL2 done
+
+### Deferred (explicit)
+- `torch` 2.5.1 → 2.10.0, `faster-whisper` 1.0.3 → 1.2.x, `openai` 1.54 → 2.x — require GPU / integration smoke on Linux before merge
+
 ## [5.1.0] - 2026-03-22
 
 ### Added

--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -39,6 +39,16 @@ Web/API слой сейчас умеет:
 - LLM уже может быть локальным или удалённым OpenAI-compatible endpoint.
 - Если LLM вынесен на другой хост, настройте `vllm.base_url` и `quality_analysis.base_url`.
 
+### Windows / WSL2 (экспериментально)
+
+Основной путь — **Linux с NVIDIA GPU**. На Windows многие команды запускают стек в **WSL2**:
+
+- Установите WSL2 (Ubuntu) и Python 3.12 + `uv` внутри дистрибутива, не в native Windows Python.
+- **CUDA в WSL2** требует драйвер NVIDIA на хосте Windows и совместимой версии CUDA toolkit в WSL — см. [документацию NVIDIA](https://docs.nvidia.com/cuda/wsl-user-guide/index.html) и [Microsoft WSL GPU](https://learn.microsoft.com/en-us/windows/wsl/tutorials/gpu-compute).
+- Пути к аудио и конфигам используйте в формате Linux (`/home/...`), не `C:\...`.
+- **systemd** в WSL может быть недоступен — для daemon-режима предпочтите `main.py web` или ручной запуск `main.py run` в tmux/screen.
+- Production 24/7 и VoIP-интеграции по-прежнему ориентированы на bare-metal Linux или VM.
+
 ## Установка
 
 ```bash
@@ -108,6 +118,8 @@ uv run python main.py web --host 0.0.0.0 --port 8080
 ```
 
 Ключ передаётся через `X-API-Key`. В browser UI для этого есть отдельное поле.
+
+За reverse-proxy (nginx, Caddy) лимит upload-запросов считается по первому значению `X-Forwarded-For`. Настройте прокси так, чтобы клиентский IP передавался корректно, или ограничивайте rate limit на уровне прокси.
 
 ### Альтернативный продвинутый запуск
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,26 @@ uv run python main.py run
 
 Use this mode when VoIP downloaders or other systems write recordings into `input/`.
 
+### Minimal first-run (no Telegram or Google Sheets)
+
+You do not need Telegram bot tokens or Google Sheets credentials for the core pipeline. Disable optional integrations in `config.yaml`:
+
+```yaml
+analytics:
+  telegram:
+    enabled: false
+
+google_sheets:
+  enabled: false
+```
+
+With this setup, both entry modes still work:
+
+- `uv run python main.py web` — upload a file, get transcript + classification + local artifacts under `output/` and `metadata/`.
+- `uv run python main.py run` — drop files into `input/` and process them with the same ASR → LLM flow.
+
+You still need a reachable OpenAI-compatible LLM if `vllm.enabled: true` (local vLLM/llama.cpp gateway or remote endpoint). Quality analysis stays optional via `quality_analysis.enabled`.
+
 ## Artifact model
 
 The web layer and the daemon share the same persisted artifact story:

--- a/README_EN.md
+++ b/README_EN.md
@@ -131,6 +131,26 @@ uv run python main.py run
 
 Use this when VoIP downloaders or another upstream process write audio into `input/`.
 
+## Minimal first-run (no Telegram or Google Sheets)
+
+Telegram and Google Sheets are optional. For a first local run, disable them in `config.yaml`:
+
+```yaml
+analytics:
+  telegram:
+    enabled: false
+
+google_sheets:
+  enabled: false
+```
+
+Core processing still works:
+
+- `main.py web` — upload and review results with artifacts under `output/` and `metadata/`.
+- `main.py run` — watch `input/` and process files through ASR → LLM.
+
+You still need a reachable OpenAI-compatible LLM when `vllm.enabled: true`. Enable `quality_analysis` only when you have the provider credentials configured.
+
 ## Artifact model
 
 Each persisted analysis is keyed by the source stem and typically produces:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -2,6 +2,11 @@
 #
 # ШАБЛОН БЕЗОПАСНОЙ КОНФИГУРАЦИИ
 # Скопируйте в config.yaml и заполните реальными значениями
+#
+# Minimal first-run (no Telegram / Google Sheets):
+#   analytics.telegram.enabled: false
+#   google_sheets.enabled: false
+# Core ASR → LLM → local artifacts still works. See README.md § Minimal first-run.
 
 # ⭐ ASR configuration (Whisper)
 # model_preset: "auto" = detect GPU VRAM and select best model

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ These are useful, but not required reading for every adopter.
 
 | Document | Description |
 |----------|-------------|
+| [reviews/STAFF_REVIEW_2026-06.md](reviews/STAFF_REVIEW_2026-06.md) | Staff-level audit before v5.2.0; tech-delta and deferred GPU upgrades. |
 | [PRODUCTIZATION_PLAN.md](PRODUCTIZATION_PLAN.md) | Strategic rationale and productization notes. Read as context, not as the live task tracker. |
 | [PILOT_OUTREACH_PLAYBOOK.md](PILOT_OUTREACH_PLAYBOOK.md) | Narrow outreach and first pilot conversation playbook. |
 | [WORKING_TOGETHER.md](WORKING_TOGETHER.md) | Collaboration paths that preserve the open-source core. |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -29,11 +29,13 @@ Backlog and direction for [Scanovich.ai-audio-call](https://github.com/FUYOH666/
 - [x] Minimal web UI for upload-and-review demos (`src/web/`)
 - [x] HTTP API for single-file analysis and orchestration (`/healthz`, `/analyze`)
 - [x] Recent analyses page backed by persisted artifacts in `output/`, `metadata/`, and `quality_analysis/`
+- [x] Minimal first-run docs (no Telegram / Google Sheets) in README and deployment guide
 - [ ] Pilot hardening for web/API: rate limiting, upload quotas, audit-friendly logs, and clearer protected-demo operations
 - [x] One-command web launch and clearer deployment path via `main.py web`
 - [x] Filtering, pagination, and search for recent analyses
 - [ ] Better detail views and export/share actions for saved analyses
 - [ ] CI/CD hardening (already: GitHub Actions)
+- [x] WSL2 deployment notes in `DEPLOYMENT_GUIDE.md`
 
 **Local-first deployment**
 
@@ -41,6 +43,7 @@ Backlog and direction for [Scanovich.ai-audio-call](https://github.com/FUYOH666/
 - [ ] Clear deployment profiles: all-local GPU, CPU worker + remote ASR, remote LLM
 - [ ] Shared config defaults to reduce drift between `vllm` and `quality_analysis`
 - [ ] Public website to protected pilot bridge with a clean demo URL strategy and no shared runtime code
+- [ ] GPU smoke validation before bumping `torch`, `faster-whisper`, and `openai` SDK (see `docs/reviews/STAFF_REVIEW_2026-06.md`)
 
 ## Longer term (3–12 months)
 
@@ -61,4 +64,4 @@ Backlog and direction for [Scanovich.ai-audio-call](https://github.com/FUYOH666/
 2. Follow [CONTRIBUTING.md](../CONTRIBUTING.md) (ruff, tests)  
 3. Update docs when behavior or config changes  
 
-_Last updated: 2026-03-22 (docs refresh and recent-analyses update)_
+_Last updated: 2026-06-12 (v5.2.0 maintenance release: staff review, minimal-mode docs, WSL2 notes)_

--- a/docs/reviews/STAFF_REVIEW_2026-06.md
+++ b/docs/reviews/STAFF_REVIEW_2026-06.md
@@ -1,0 +1,107 @@
+# Staff review — main @ v5.1.0 (2026-06)
+
+Baseline: full repository on `main` before v5.2.0 release. Scope includes pipeline core, web/API, config, ops, and integrations. Excludes vendored VoIP vendor credentials and production `.env` values.
+
+## Scope
+
+**Goal:** Assess readiness for a maintenance release after ~2 months without pushes; identify safe improvements vs GPU-heavy dependency jumps.
+
+**Modules reviewed:**
+
+| Layer | Paths |
+|-------|--------|
+| Pipeline | `src/pipeline_service.py`, `src/asr.py`, `src/vllm_postprocessor.py`, `src/quality_analyzer.py` |
+| Web/API | `src/web/app.py`, `src/web/static/` |
+| Config | `src/config_validation.py`, `config.example.yaml` |
+| Ops | `src/daemon_watcher.py`, `Dockerfile`, `.github/workflows/ci.yml` |
+| CLI | `src/cli/commands.py` |
+
+**Assumptions:** Local-first deployment; optional Telegram/Sheets; GPU smoke for ASR/torch deferred to a follow-up release.
+
+## Correctness & logic
+
+- Shared pipeline (`CallAnalysisPipeline`) has clear validation for extensions and file size; temp preprocessed audio is cleaned in `finally`.
+- Web upload streams in 1 MiB chunks with size cap; temp dir removed after `/analyze`.
+- `result_id` path traversal mitigated via `Path(result_id).name` check.
+- Quality analysis can run with temporary artifacts when `persist=False` — temp files cleaned in `finally`.
+- **Finding:** `config.example.yaml` enables Telegram and Google Sheets by default while Pydantic defaults disable them — newcomers copying the example may think integrations are required (docs gap, not runtime bug).
+
+## Architecture fit
+
+- Single pipeline reused by CLI and web — good separation.
+- Web layer is thin over filesystem artifacts for history — appropriate for pilot scope.
+- Version string duplicated in `src/__init__.py`, `src/web/app.py` — drift risk (should-fix, fixed in v5.2.0).
+- `vllm.base_url` and `quality_analysis.base_url` can diverge — documented in deployment guide; optional env sync left to operators.
+
+## Security & privacy
+
+- Optional `X-API-Key` on `/analyze` and history endpoints when `web.require_api_key=true`.
+- Public bind without API key rejected in CLI `web` command.
+- 500 responses hide internal exception text; errors logged server-side.
+- Upload extension allowlist and rate limiting (in-memory per client IP) present.
+- **Nit:** In-memory rate limit does not survive multi-worker uvicorn — acceptable for demo/pilot single process.
+- **Nit:** `X-Forwarded-For` trusted for rate limit identity — document reverse-proxy requirement for pilots.
+
+## Reliability & ops
+
+- `/healthz` reports ASR device/model and optional vLLM health.
+- Docker HEALTHCHECK hits `/healthz`.
+- Structured logging via `setup_logging` on web startup.
+- **Should-fix:** `pytest` without `tests/` path collects broken `voip/rostelcom/tests` (import collision) — fixed via `norecursedirs` in v5.2.0.
+
+## Performance
+
+- ASR and LLM run in `asyncio.to_thread` from web handlers — avoids blocking event loop.
+- No N+1 on history listing beyond filesystem glob — acceptable for pilot scale.
+
+## Tests & verification
+
+Commands run:
+
+```bash
+uv run pytest tests/ -q --tb=short   # 34 passed
+uv run ruff check src/web src/pipeline_service.py tests/test_api.py tests/test_cli_web.py
+```
+
+Coverage: web API (auth, rate limit, history, safe 500), CLI web launch, config validation, script parser.
+
+**Gap:** No integration test with real GPU ASR — expected for CI; document GPU smoke as release follow-up.
+
+## Docs & DX
+
+- README/ROADMAP strong for product surface; **minimal first-run without Telegram/Sheets missing** — addressed in v5.2.0.
+- WSL2 notes absent from `DEPLOYMENT_GUIDE.md` — short section added in v5.2.0 (closes good-first-issue intent for #18).
+- Staff review artifact (this file) added for evaluator trust signal.
+
+## Tech-delta matrix (2026-03 → 2026-06)
+
+| Package | Pinned | Available | Tier | v5.2.0 action |
+|---------|--------|-----------|------|----------------|
+| actions/checkout | v4 | v6 | A | Upgrade CI |
+| astral-sh/setup-uv | v5 | v7 | A | Upgrade CI |
+| pydantic | 2.10.3 | 2.12.5 | A | Upgrade if tests pass |
+| pydantic-settings | 2.6.1 | 2.7.x | A | Upgrade with pydantic |
+| faster-whisper | 1.0.3 | 1.2.1 | B | **Deferred** — GPU smoke pending |
+| torch/torchaudio | 2.5.1 | 2.10.0 | C | **Not in v5.2.0** — CUDA matrix risk |
+| openai SDK | 1.54.0 | 2.29.0 | B | **Deferred** — major API review needed |
+
+## Grand opportunities (max 3)
+
+1. **HTTP ASR adapter** (ROADMAP) — high impact for MacBook + remote GPU; medium effort; not v5.2.0.
+2. **torch + faster-whisper bump after GPU smoke** — medium impact on latency/compat; high effort validation.
+3. **Multi-worker safe rate limiting** (Redis or proxy-level) — pilot hardening; medium effort.
+
+## Findings summary
+
+| ID | Severity | Location | Recommendation |
+|----|----------|----------|----------------|
+| SR-01 | should-fix | `pytest.ini` / root pytest | Exclude `voip/` from collection — **fixed v5.2.0** |
+| SR-02 | should-fix | `src/__init__.py`, `src/web/app.py` | Single version source — **fixed v5.2.0** |
+| SR-03 | should-fix | `README.md`, `README_EN.md` | Document minimal mode — **fixed v5.2.0** |
+| SR-04 | nit | `config.example.yaml` | Example enables integrations; docs clarify minimal snippet — **fixed v5.2.0** |
+| SR-05 | nit | `src/web/app.py` rate limit | Document proxy/`X-Forwarded-For` in deployment guide — **fixed v5.2.0** |
+| SR-06 | defer | `pyproject.toml` torch/faster-whisper/openai | GPU smoke before bump — **CHANGELOG note** |
+
+## Verdict
+
+**Ready for v5.2.0 release after Wave A:** docs, CI actions, patch pydantic, version sync, pytest scope fix. **No blockers** for a documentation and maintenance release. GPU-heavy dependency upgrades explicitly deferred.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "call-analytics-platform"
-version = "5.1.0"
+version = "5.2.0"
 description = "Local-first call analytics platform with shared pipeline, pilot-ready API/UI, and on-prem deployment paths"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
@@ -38,8 +38,8 @@ dependencies = [
     "torch==2.5.1",
     "torchaudio==2.5.1",
     # ⭐ Configuration & Validation - критичные версии
-    "pydantic==2.10.3",
-    "pydantic-settings==2.6.1",
+    "pydantic==2.12.5",
+    "pydantic-settings==2.7.1",
     # ⭐ Configuration & Validation - диапазоны
     "pyyaml>=6.0.0,<7.0.0",
     "python-dotenv>=1.0.0,<2.0.0",
@@ -166,6 +166,7 @@ reportUnusedClass = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+norecursedirs = ["voip", ".git", ".venv", "venv", "build", "dist"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,8 @@
-[tool:pytest]
+[pytest]
 minversion = 7.0
 addopts = -ra -q --strict-markers --strict-config
 testpaths = tests
+norecursedirs = voip .git .venv venv build dist
 python_files = test_*.py *_test.py
 python_classes = Test*
 python_functions = test_*

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """Call Analytics Platform — transcription and call-quality analysis."""
 
-__version__ = "5.1.0"
+__version__ = "5.2.0"
 

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -21,6 +21,7 @@ from fastapi import FastAPI, File, Header, HTTPException, Request, UploadFile
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
+from src import __version__
 from src.pipeline_service import CallAnalysisPipeline
 from src.utils import ConfigManager, setup_logging
 
@@ -54,7 +55,7 @@ def create_app(
 
     app = FastAPI(
         title="Call Analytics Platform API",
-        version="5.1.0",
+        version=__version__,
         lifespan=lifespan,
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -83,7 +83,7 @@ wheels = [
 
 [[package]]
 name = "call-analytics-platform"
-version = "5.1.0"
+version = "5.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -141,8 +141,8 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.26.0,<2.0.0" },
     { name = "nvidia-ml-py", specifier = "==12.560.30" },
     { name = "openai", specifier = "==1.54.0" },
-    { name = "pydantic", specifier = "==2.10.3" },
-    { name = "pydantic-settings", specifier = "==2.6.1" },
+    { name = "pydantic", specifier = "==2.12.5" },
+    { name = "pydantic-settings", specifier = "==2.7.1" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0,<9.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0,<1.0.0" },
@@ -990,54 +990,59 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.10.3"
+version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
     { name = "pydantic-core" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/0f/27908242621b14e649a84e62b133de45f84c255eecb350ab02979844a788/pydantic-2.10.3.tar.gz", hash = "sha256:cb5ac360ce894ceacd69c403187900a02c4b20b693a9dd1d643e1effab9eadf9", size = 786486, upload-time = "2024-12-03T15:59:02.347Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/51/72c18c55cf2f46ff4f91ebcc8f75aa30f7305f3d726be3f4ebffb4ae972b/pydantic-2.10.3-py3-none-any.whl", hash = "sha256:be04d85bbc7b65651c5f8e6b9976ed9c6f41782a55524cef079a34a0bb82144d", size = 456997, upload-time = "2024-12-03T15:58:59.867Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
 ]
 
 [[package]]
 name = "pydantic-core"
-version = "2.27.1"
+version = "2.41.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/9f/7de1f19b6aea45aeb441838782d68352e71bfa98ee6fa048d5041991b33e/pydantic_core-2.27.1.tar.gz", hash = "sha256:62a763352879b84aa31058fc931884055fd75089cccbd9d58bb6afd01141b235", size = 412785, upload-time = "2024-11-22T00:24:49.865Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/51/2e9b3788feb2aebff2aa9dfbf060ec739b38c05c46847601134cc1fed2ea/pydantic_core-2.27.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:9cbd94fc661d2bab2bc702cddd2d3370bbdcc4cd0f8f57488a81bcce90c7a54f", size = 1895239, upload-time = "2024-11-22T00:22:13.775Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/9e/f8063952e4a7d0127f5d1181addef9377505dcce3be224263b25c4f0bfd9/pydantic_core-2.27.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5f8c4718cd44ec1580e180cb739713ecda2bdee1341084c1467802a417fe0f02", size = 1805070, upload-time = "2024-11-22T00:22:15.438Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/9d/e1d6c4561d262b52e41b17a7ef8301e2ba80b61e32e94520271029feb5d8/pydantic_core-2.27.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:15aae984e46de8d376df515f00450d1522077254ef6b7ce189b38ecee7c9677c", size = 1828096, upload-time = "2024-11-22T00:22:17.892Z" },
-    { url = "https://files.pythonhosted.org/packages/be/65/80ff46de4266560baa4332ae3181fffc4488ea7d37282da1a62d10ab89a4/pydantic_core-2.27.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1ba5e3963344ff25fc8c40da90f44b0afca8cfd89d12964feb79ac1411a260ac", size = 1857708, upload-time = "2024-11-22T00:22:19.412Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/ca/3370074ad758b04d9562b12ecdb088597f4d9d13893a48a583fb47682cdf/pydantic_core-2.27.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:992cea5f4f3b29d6b4f7f1726ed8ee46c8331c6b4eed6db5b40134c6fe1768bb", size = 2037751, upload-time = "2024-11-22T00:22:20.979Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/e2/4ab72d93367194317b99d051947c071aef6e3eb95f7553eaa4208ecf9ba4/pydantic_core-2.27.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0325336f348dbee6550d129b1627cb8f5351a9dc91aad141ffb96d4937bd9529", size = 2733863, upload-time = "2024-11-22T00:22:22.951Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/c6/8ae0831bf77f356bb73127ce5a95fe115b10f820ea480abbd72d3cc7ccf3/pydantic_core-2.27.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7597c07fbd11515f654d6ece3d0e4e5093edc30a436c63142d9a4b8e22f19c35", size = 2161161, upload-time = "2024-11-22T00:22:24.785Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/f4/b2fe73241da2429400fc27ddeaa43e35562f96cf5b67499b2de52b528cad/pydantic_core-2.27.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3bbd5d8cc692616d5ef6fbbbd50dbec142c7e6ad9beb66b78a96e9c16729b089", size = 1993294, upload-time = "2024-11-22T00:22:27.076Z" },
-    { url = "https://files.pythonhosted.org/packages/77/29/4bb008823a7f4cc05828198153f9753b3bd4c104d93b8e0b1bfe4e187540/pydantic_core-2.27.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:dc61505e73298a84a2f317255fcc72b710b72980f3a1f670447a21efc88f8381", size = 2001468, upload-time = "2024-11-22T00:22:29.346Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/a9/0eaceeba41b9fad851a4107e0cf999a34ae8f0d0d1f829e2574f3d8897b0/pydantic_core-2.27.1-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:e1f735dc43da318cad19b4173dd1ffce1d84aafd6c9b782b3abc04a0d5a6f5bb", size = 2091413, upload-time = "2024-11-22T00:22:30.984Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/36/eb8697729725bc610fd73940f0d860d791dc2ad557faaefcbb3edbd2b349/pydantic_core-2.27.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:f4e5658dbffe8843a0f12366a4c2d1c316dbe09bb4dfbdc9d2d9cd6031de8aae", size = 2154735, upload-time = "2024-11-22T00:22:32.616Z" },
-    { url = "https://files.pythonhosted.org/packages/52/e5/4f0fbd5c5995cc70d3afed1b5c754055bb67908f55b5cb8000f7112749bf/pydantic_core-2.27.1-cp312-none-win32.whl", hash = "sha256:672ebbe820bb37988c4d136eca2652ee114992d5d41c7e4858cdd90ea94ffe5c", size = 1833633, upload-time = "2024-11-22T00:22:35.027Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/f2/c61486eee27cae5ac781305658779b4a6b45f9cc9d02c90cb21b940e82cc/pydantic_core-2.27.1-cp312-none-win_amd64.whl", hash = "sha256:66ff044fd0bb1768688aecbe28b6190f6e799349221fb0de0e6f4048eca14c16", size = 1986973, upload-time = "2024-11-22T00:22:37.502Z" },
-    { url = "https://files.pythonhosted.org/packages/df/a6/e3f12ff25f250b02f7c51be89a294689d175ac76e1096c32bf278f29ca1e/pydantic_core-2.27.1-cp312-none-win_arm64.whl", hash = "sha256:9a3b0793b1bbfd4146304e23d90045f2a9b5fd5823aa682665fbdaf2a6c28f3e", size = 1883215, upload-time = "2024-11-22T00:22:39.186Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
 ]
 
 [[package]]
 name = "pydantic-settings"
-version = "2.6.1"
+version = "2.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/d4/9dfbe238f45ad8b168f5c96ee49a3df0598ce18a0795a983b419949ce65b/pydantic_settings-2.6.1.tar.gz", hash = "sha256:e0f92546d8a9923cb8941689abf85d6601a8c19a23e97a34b2964a2e3f813ca0", size = 75646, upload-time = "2024-11-01T11:00:05.17Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/7b/c58a586cd7d9ac66d2ee4ba60ca2d241fa837c02bca9bea80a9a8c3d22a9/pydantic_settings-2.7.1.tar.gz", hash = "sha256:10c9caad35e64bfb3c2fbf70a078c0e25cc92499782e5200747f942a065dec93", size = 79920, upload-time = "2024-12-31T11:27:44.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/f9/ff95fd7d760af42f647ea87f9b8a383d891cdb5e5dbd4613edaeb094252a/pydantic_settings-2.6.1-py3-none-any.whl", hash = "sha256:7fb0637c786a558d3103436278a7c4f1cfd29ba8973238a50c5bb9a55387da87", size = 28595, upload-time = "2024-11-01T11:00:02.64Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/46/93416fdae86d40879714f72956ac14df9c7b76f7d41a4d68aa9f71a0028b/pydantic_settings-2.7.1-py3-none-any.whl", hash = "sha256:590be9e6e24d06db33a4262829edef682500ef008565a969c73d39d5f8bfb3fd", size = 29718, upload-time = "2024-12-31T11:27:43.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Staff review artifact (`docs/reviews/STAFF_REVIEW_2026-06.md`) and tech-delta matrix
- Minimal first-run docs (no Telegram / Google Sheets) in README RU/EN
- WSL2 notes in DEPLOYMENT_GUIDE, pytest voip exclusion fix
- pydantic 2.12.5 / pydantic-settings 2.7.1
- Version bump to 5.2.0

## Deferred
- torch, faster-whisper, openai SDK — GPU smoke pending
- CI actions v6/v7 — apply via GitHub UI (local push lacks workflow OAuth scope)

## Test plan
- [x] `uv run pytest tests/ -q`
- [x] `uv run ruff check src/web src/pipeline_service.py tests/test_api.py tests/test_cli_web.py`

Made with [Cursor](https://cursor.com)